### PR TITLE
LEGO-499 — На странице js API "свалился" тип метода

### DIFF
--- a/src/blocks/common.blocks/block-jsdoc/__title/block-jsdoc__title.deps.yaml
+++ b/src/blocks/common.blocks/block-jsdoc/__title/block-jsdoc__title.deps.yaml
@@ -1,3 +1,6 @@
 - mods:
     h: ['2', '5', '6']
-    mix: ['post-title', 'post-title-inline']
+
+- block: post
+  elem: title
+  inline: yes

--- a/src/blocks/common.blocks/block-jsdoc/block-jsdoc.bemtree
+++ b/src/blocks/common.blocks/block-jsdoc/block-jsdoc.bemtree
@@ -50,7 +50,8 @@ block('block-jsdoc')(
                         content: [
                             {
                                 elem: 'title',
-                                elemMods: { mix: 'post-title-inline', h: '5' },
+                                elemMods: { h: '5' },
+                                mix: { block: 'post', elem: 'title', mods: { inline: 'yes' } },
                                 content: {
                                     elem: 'selection',
                                     elemMods: { color: 'gold' },


### PR DESCRIPTION
Было
![1](https://cloud.githubusercontent.com/assets/1333220/4401731/b034b640-4490-11e4-8a8d-bf03620260df.png)
Стало
![2](https://cloud.githubusercontent.com/assets/1333220/4401741/bf798dec-4490-11e4-833e-40ebd276b33f.png)
