### PR TITLE
LEGO-502 — Неправильная ссылка на создание issue

### DIFF
--- a/src/blocks/common.blocks/post/_view/post_view_full.bemtree
+++ b/src/blocks/common.blocks/post/_view/post_view_full.bemtree
@@ -123,7 +123,10 @@ block post, mod view full {
     }
 
     issue: {
-        var repo = this.ctx.content;
+        var repo = this.ctx.content,
+            repoSt = ['manifest', 'a11y-manual', 'islands-guidelines'];//repo who does not have issues on github
+
+        repo.issue = (repoSt.indexOf(repo.repo) >=0) ? 'https://st.yandex-team.ru/createTicket?queue=LEGO' : repo.issue;
 
         if(!repo) return [];
 


### PR DESCRIPTION
Было предложение внизу каждой страницы
"Если вы заметили ошибку или хотите чем-то дополнить статью, вы всегда можете или написать об этом на Гитхабе".
Ссылка вела на создание нового issue. Проблема в том, что у нас не во всех репозиториях есть секции issues. 
Для некоторых сделала исключение и ссылки там ведут на стартрек. 
Чтобы не добавлять лишние проверки, окончание предложения "на Гитхабе" оторвала.
