### PR TITLE
Update version of bse-admin to v0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "level": "~0.18.0",
     "tar": "1.0.1",
     "luster": "~0.5.1",
-    "bse-admin": "git://github.com/bem/bse-admin.git#v0.4.3"
+    "bse-admin": "git://github.com/bem/bse-admin.git#v0.4.6"
   },
   "devDependencies": {
     "bem-site-codestyle": "~0.1.0",


### PR DESCRIPTION
@gela-d @tavriaforever 

Fix issue with missed breadcrumbs. Update version of bse-admin to v0.4.6
