### PR TITLE
Fix layout when press key up/down on windows

### DIFF
--- a/src/blocks/common.blocks/page/_search/page_search.js
+++ b/src/blocks/common.blocks/page/_search/page_search.js
@@ -8,6 +8,7 @@ modules.define('page', ['jquery', 'keyboard__codes'], function (provide, $, keyb
                     var _this = this;
                     this._searchButton = this.findBlockInside('search-button');
                     this._searchPanel = this.findBlockInside('search-panel');
+                    this._searchForm = this.findBlockInside('search-form');
                     this._contentWrapper = this.findBlockInside('content-wrapper');
 
                     this.bindToDoc('click keyup', function (e) {
@@ -20,18 +21,24 @@ modules.define('page', ['jquery', 'keyboard__codes'], function (provide, $, keyb
         },
 
         _toggleSearch: function (e, target) {
-            if (e.type === 'keyup' && e.which === keyboard.ESC) {
-                this._searchPanel.delMod('state');
+            var sBtn = this._searchButton,
+                sPanel = this._searchPanel,
+                sForm = this._searchForm,
+                cWrapper = this._contentWrapper;
 
+            if (sForm.containsDomElem(target)) return false;
+
+            if (e.type === 'keyup' && e.which === keyboard.ESC) {
+                sPanel.delMod('state');
                 return false;
             }
 
-            if (this._searchButton.containsDomElem(target) || this._searchPanel.containsDomElem(target)) {
-                this._searchPanel.setMod('state', 'open');
-                this._searchButton.setMod('active', true);
-            } else if (this._contentWrapper.containsDomElem(target)) {
-                this._searchPanel.delMod('state');
-                this._searchButton.delMod('active');
+            if (sPanel.containsDomElem(target) || sBtn.containsDomElem(target)) {
+                sPanel.toggleMod('state', 'open');
+                sBtn.toggleMod('active', true);
+            } else if (cWrapper.containsDomElem(target)) {
+                sPanel.delMod('state');
+                sBtn.delMod('active');
             }
         }
     }));

--- a/src/blocks/common.blocks/search-panel/search-panel.styl
+++ b/src/blocks/common.blocks/search-panel/search-panel.styl
@@ -1,5 +1,6 @@
 .search-panel
 {
+    display: none;
     position: absolute;
     z-index: 1001;
     top: 0;
@@ -12,13 +13,20 @@
     height: 100%;
     padding: 20px;
 
-    transition: right .3s ease-out;
-
     background-color: #fafafa;
     box-shadow: 0 0 2px 0 rgba(0,0,0,.3);
 
     &_state_open
     {
-        right: 0;
+        display: block;
+
+        animation: slideLeft .6s .1s 1 both;
     }
+}
+
+
+@keyframes slideLeft
+{
+    0% { right: -350px; }
+    100% { right: 0; }
 }


### PR DESCRIPTION
@gela-d 
I hide slide block and show it only when panel must open.
For saving animate, I changed css from `transition` to `animate` and added `0.1s` delay for set `display: block` before starting the animation. 
p.s. Only for windows os
