### PR TITLE
FEI-593 Fix 500-errors for some blocks

### DIFF
--- a/src/blocks/common.blocks/block/block.bemtree
+++ b/src/blocks/common.blocks/block/block.bemtree
@@ -130,9 +130,8 @@ block('block')(
             data = data[this.ctx.lang] || data;
             examples = data.examples;
 
-            if (!examples || !examples.length) {
-                return false;
-            }
+            // FEI-593
+            if (!examples || !examples.filter(Boolean).length) return false;
 
             length = examples.length;
 


### PR DESCRIPTION
Сейчас enb-bem-docs, неправильно собирает структуру примеров для некоторых блоков
Завел соответствующую задачу, а здесь добавил проверку в шаблонах

@gela-d 
@tadatuta 
